### PR TITLE
fixture for default admin user

### DIFF
--- a/store-after/test/fixtures/admin_users.yml
+++ b/store-after/test/fixtures/admin_users.yml
@@ -4,7 +4,6 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-#  column: value
+admin:
+  email: admin@example.com
+  encrypted_password: $2a$10$LBaRtYUkC2TqRZzqyQbGIeyTj9.HiF46QqZFS8YgaL4iJQxpoObPK


### PR DESCRIPTION
Out of the box, the README leaves you with a blank admin user. One is created by the migration but then overwritten by the `rake db:fixtures:load`. I just pulled the admin user, including encrypted password, into the admin users fixture.
